### PR TITLE
Use a UserAgent to identify when it is the AccessibilityReporter requesting a page

### DIFF
--- a/src/AccessibilityReporter/App_Plugins/AccessibilityReporter/accessibility-reporter.service.js
+++ b/src/AccessibilityReporter/App_Plugins/AccessibilityReporter/accessibility-reporter.service.js
@@ -7,8 +7,15 @@ class AccessibilityReporter {
         return new Promise(async (resolve, reject) => {
 
             try {
-
-                const testRequest = new Request(testUrl);
+                const headers = new Headers({
+                    'User-Agent': 'AccessibilityReporter/1.0'
+                });
+                
+                const testRequest = new Request(testUrl, {
+                    method: 'GET',
+                    headers: headers
+                });
+                
                 await fetch(testRequest);
                 const iframeId = "arTestIframe" + AccessibilityReporter.randomUUID();
                 const container = document.getElementById(showWhileRunning ? 'dashboard-ar-tests' : 'contentcolumn');


### PR DESCRIPTION
Hi @mattbegent 

Essentially we had a need to on a site to ignore the Cookie Popup when the AccessibilityReported requests a page...

... and the Cookie Popup thing could be configured to ignore certain requests by UserAgent...

and I maybe totally mistaken in these things, but I couldn't see anything that would identify it was the AccessibilityReporter that had come-a-calling...

I've created this PR to illustrate what I mean (but of course this might not be the correct way to do it, I might have misread the bit that actually requests the page to be tested!)

Anyway be great if this was an interesting addition to the package, but if it's plain stupidity lets just close it and pretend I never mentioned it.

regards

marc