### PR TITLE
Renames User-Agent header

### DIFF
--- a/src/AccessibilityReporter/App_Plugins/AccessibilityReporter/accessibility-reporter.service.js
+++ b/src/AccessibilityReporter/App_Plugins/AccessibilityReporter/accessibility-reporter.service.js
@@ -8,7 +8,7 @@ class AccessibilityReporter {
 
             try {
                 const headers = new Headers({
-                    'User-Agent': 'AccessibilityReporter/1.0'
+                    'X-User-Agent': 'AccessibilityReporter/1.0'
                 });
 
                 const testRequest = new Request(testUrl, {


### PR DESCRIPTION
Updates the request header name from 'User-Agent' to 'X-User-Agent'.

Fixes an issue where the User-Agent wasn't being set because the User-Agent header is restricted and cannot be modified by JavaScript for security reasons. Adds a custom header that can be checked against.